### PR TITLE
Improve frontend validation and styling

### DIFF
--- a/frontend/src/main/java/com/example/frontend/controller/WebController.java
+++ b/frontend/src/main/java/com/example/frontend/controller/WebController.java
@@ -1,55 +1,63 @@
 package com.example.frontend.controller;
 
 import com.example.frontend.client.BookClient;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
 @Validated
 public class WebController {
-    private final BookClient client;
-    public WebController(BookClient client) { this.client = client; }
+  private final BookClient client;
+  public WebController(BookClient client) { this.client = client; }
 
-    @GetMapping("/")
-    public String index() { return "index"; }
+  @GetMapping("/")
+  public String index() { return "index"; }
 
-    @GetMapping("/books")
-    public String list(Model model) {
-        model.addAttribute("books", client.list());
-        return "list";
+  @GetMapping("/books")
+  public String list(Model model) {
+    model.addAttribute("books", client.list());
+    return "list";
+  }
+
+  @GetMapping("/books/add")
+  public String add(Model model) {
+    model.addAttribute("form", new BookForm());
+    return "add";
+  }
+
+  @PostMapping("/books")
+  public String create(@ModelAttribute("form") @Valid BookForm form,
+                       BindingResult binding,
+                       Model model) {
+    if (binding.hasErrors()) {
+      return "add";
     }
+    BookClient.BookDto dto = new BookClient.BookDto();
+    dto.setTitle(form.title);
+    dto.setAuthor(form.author);
+    dto.setIsbn(form.isbn);
+    dto.setPrice(form.price);
+    client.create(dto);
+    return "redirect:/books";
+  }
 
-    @GetMapping("/books/add")
-    public String add(Model model) {
-        model.addAttribute("form", new BookForm());
-        return "add";
-    }
+  @PostMapping("/books/{id}/delete")
+  public String delete(@PathVariable String id) {
+    client.delete(id);
+    return "redirect:/books";
+  }
 
-    @PostMapping("/books")
-    public String create(@ModelAttribute("form") @Validated BookForm form) {
-        BookClient.BookDto dto = new BookClient.BookDto();
-        dto.setTitle(form.title);
-        dto.setAuthor(form.author);
-        dto.setIsbn(form.isbn);
-        dto.setPrice(form.price);
-        client.create(dto);
-        return "redirect:/books";
-    }
-
-    @PostMapping("/books/{id}/delete")
-    public String delete(@PathVariable String id) {
-        client.delete(id);
-        return "redirect:/books";
-    }
-
-    public static class BookForm {
-        @NotBlank public String title;
-        @NotBlank public String author;
-        @NotBlank public String isbn;
-        @NotNull  public Double price;
-    }
+  public static class BookForm {
+    @NotBlank public String title;
+    @NotBlank public String author;
+    @NotBlank public String isbn;
+    @NotNull  public Double price;
+  }
 }
+

--- a/frontend/src/main/resources/static/styles.css
+++ b/frontend/src/main/resources/static/styles.css
@@ -1,0 +1,75 @@
+:root{
+  --bg:#0b1020;
+  --card:#121a2fcc;
+  --text:#e8eeff;
+  --muted:#94a3b8;
+  --primary:#5b8cff;
+  --danger:#ff6464;
+  --border:#25314f;
+  --ring:#7aa2ff55;
+}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body.page{
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji";
+  background: radial-gradient(1200px 600px at 20% -10%, #152345 10%, #0b1020 60%), linear-gradient(180deg, #0b1020, #0b1020);
+  color:var(--text);
+  min-height:100vh;
+  display:flex;
+  flex-direction:column;
+}
+
+.topbar{
+  position:sticky; top:0; z-index:10;
+  backdrop-filter:saturate(160%) blur(8px);
+  background: #0b1020bb;
+  border-bottom:1px solid var(--border);
+  display:flex; align-items:center; justify-content:space-between;
+  padding:12px 20px;
+}
+.brand{font-weight:700;letter-spacing:.2px}
+.nav{display:flex;gap:10px;align-items:center}
+.nav-link{
+  color:var(--muted); text-decoration:none; padding:8px 10px; border-radius:10px;
+}
+.nav-link.active{color:var(--text); background:#ffffff10}
+.btn{
+  border:1px solid var(--border); background:#ffffff10; color:var(--text);
+  padding:8px 14px; border-radius:12px; text-decoration:none; cursor:pointer; display:inline-block;
+}
+.btn:hover{box-shadow:0 0 0 3px var(--ring)}
+.btn-primary{background:var(--primary); border-color:#3c6cf0}
+.btn-danger{background:var(--danger); border-color:#e05555}
+.btn.active{background:#ffffff15}
+
+.container{max-width:1000px; margin:32px auto; padding:0 18px; width:100%}
+.card{
+  background:var(--card); border:1px solid var(--border); border-radius:16px;
+  box-shadow:0 10px 30px #00000033; padding:18px;
+}
+.card.hero{padding:28px}
+.card-header{display:flex; align-items:center; justify-content:space-between; margin-bottom:12px}
+.muted{color:var(--muted)}
+.center{text-align:center}
+.actions{display:flex; gap:10px; margin-top:10px}
+
+.table-wrap{overflow:auto}
+.table{width:100%; border-collapse:separate; border-spacing:0}
+.table th,.table td{padding:12px 10px; border-bottom:1px solid var(--border)}
+.table th{color:var(--muted); text-align:left; font-weight:600}
+.table td.num{text-align:right}
+
+.form-grid{display:grid; gap:14px; grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+.field{display:flex; flex-direction:column; gap:6px}
+.field input{
+  padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:#0b1125; color:var(--text);
+}
+.field input:focus{outline:none; box-shadow:0 0 0 3px var(--ring)}
+.error{color:#ff8080; font-size:.9rem}
+
+.footer{
+  margin-top:auto; padding:16px; text-align:center; color:var(--muted);
+  border-top:1px solid var(--border); background:#0b1020bb; backdrop-filter: blur(4px);
+}
+

--- a/frontend/src/main/resources/templates/add.html
+++ b/frontend/src/main/resources/templates/add.html
@@ -1,15 +1,62 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Add Book</title></head>
-<body>
-<h2>Add Book</h2>
-<p><a href="/">Home</a> | <a href="/books">Back to list</a></p>
-<form action="/books" method="post">
-  <label>Title: <input type="text" name="title" required></label><br/>
-  <label>Author: <input type="text" name="author" required></label><br/>
-  <label>ISBN: <input type="text" name="isbn" required></label><br/>
-  <label>Price: <input type="number" step="0.01" name="price" required></label><br/>
-  <button type="submit">Save</button>
-</form>
+<head>
+  <meta charset="UTF-8">
+  <title>Add Book</title>
+  <link rel="stylesheet" th:href="@{/styles.css}">
+</head>
+<body class="page">
+  <header class="topbar">
+    <div class="brand">📚 Book Management</div>
+    <nav class="nav">
+      <a href="/" class="nav-link">Home</a>
+      <a href="/books" class="nav-link">Books</a>
+      <a href="/books/add" class="btn active">Add Book</a>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="card">
+      <div class="card-header">
+        <h2>Add a New Book</h2>
+      </div>
+
+      <form th:action="@{/books}" th:object="${form}" method="post" class="form-grid">
+        <div class="field">
+          <label>Title</label>
+          <input th:field="*{title}" placeholder="e.g. Clean Code" required>
+          <div class="error" th:if="${#fields.hasErrors('title')}" th:errors="*{title}"></div>
+        </div>
+
+        <div class="field">
+          <label>Author</label>
+          <input th:field="*{author}" placeholder="e.g. Robert C. Martin" required>
+          <div class="error" th:if="${#fields.hasErrors('author')}" th:errors="*{author}"></div>
+        </div>
+
+        <div class="field">
+          <label>ISBN</label>
+          <input th:field="*{isbn}" placeholder="e.g. 9780132350884" required>
+          <div class="error" th:if="${#fields.hasErrors('isbn')}" th:errors="*{isbn}"></div>
+        </div>
+
+        <div class="field">
+          <label>Price</label>
+          <input th:field="*{price}" type="number" step="0.01" min="0" placeholder="e.g. 34.99" required>
+          <div class="error" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></div>
+        </div>
+
+        <div class="actions">
+          <a href="/books" class="btn">Cancel</a>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+      </form>
+    </section>
+  </main>
+
+  <footer class="footer">© <span id="y"></span> Book Management • Demo
+    <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  </footer>
 </body>
 </html>
+

--- a/frontend/src/main/resources/templates/index.html
+++ b/frontend/src/main/resources/templates/index.html
@@ -1,8 +1,34 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Book Management</title></head>
-<body>
-<h2>Book Management</h2>
-<p><a href="/books">View Books</a> | <a href="/books/add">Add Book</a></p>
+<head>
+  <meta charset="UTF-8">
+  <title>Book Management</title>
+  <link rel="stylesheet" th:href="@{/styles.css}">
+  </head>
+<body class="page">
+  <header class="topbar">
+    <div class="brand">📚 Book Management</div>
+    <nav class="nav">
+      <a href="/" class="nav-link active">Home</a>
+      <a href="/books" class="nav-link">Books</a>
+      <a href="/books/add" class="btn">Add Book</a>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="card hero">
+      <h1>Manage your library with ease</h1>
+      <p class="muted">This is a simple 3-tier Java app (Frontend + Backend + MongoDB). Use the links above to view or add books.</p>
+      <div class="actions">
+        <a href="/books" class="btn btn-primary">View Books</a>
+        <a href="/books/add" class="btn">Add a Book</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">© <span id="y"></span> Book Management • Demo
+    <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  </footer>
 </body>
 </html>
+

--- a/frontend/src/main/resources/templates/list.html
+++ b/frontend/src/main/resources/templates/list.html
@@ -1,22 +1,58 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Books</title></head>
-<body>
-<h2>Books</h2>
-<p><a href="/">Home</a> | <a href="/books/add">Add Book</a></p>
-<table border="1">
-  <tr><th>Title</th><th>Author</th><th>ISBN</th><th>Price</th><th>Action</th></tr>
-  <tr th:each="b : ${books}">
-    <td th:text="${b.title}"></td>
-    <td th:text="${b.author}"></td>
-    <td th:text="${b.isbn}"></td>
-    <td th:text="${b.price}"></td>
-    <td>
-      <form th:action="@{'/books/' + ${b.id} + '/delete'}" method="post">
-        <button type="submit">Delete</button>
-      </form>
-    </td>
-  </tr>
-</table>
+<head>
+  <meta charset="UTF-8">
+  <title>Books</title>
+  <link rel="stylesheet" th:href="@{/styles.css}">
+</head>
+<body class="page">
+  <header class="topbar">
+    <div class="brand">📚 Book Management</div>
+    <nav class="nav">
+      <a href="/" class="nav-link">Home</a>
+      <a href="/books" class="nav-link active">Books</a>
+      <a href="/books/add" class="btn">Add Book</a>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="card">
+      <div class="card-header">
+        <h2>Books</h2>
+        <a href="/books/add" class="btn">+ Add Book</a>
+      </div>
+
+      <div class="table-wrap">
+        <table class="table">
+          <thead>
+          <tr>
+            <th>Title</th><th>Author</th><th>ISBN</th><th class="num">Price</th><th>Action</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:if="${#lists.isEmpty(books)}">
+            <td colspan="5" class="muted center">No books yet. Add your first one!</td>
+          </tr>
+          <tr th:each="b : ${books}">
+            <td th:text="${b.title}"></td>
+            <td th:text="${b.author}"></td>
+            <td th:text="${b.isbn}"></td>
+            <td class="num" th:text="${#numbers.formatDecimal(b.price, 1, 'COMMA', 2, 'POINT')}"></td>
+            <td>
+              <form th:action="@{'/books/' + ${b.id} + '/delete'}" method="post" onsubmit="return confirm('Delete this book?')">
+                <button type="submit" class="btn btn-danger">Delete</button>
+              </form>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">© <span id="y"></span> Book Management • Demo
+    <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  </footer>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Handle form validation errors in WebController and stay on add page
- Revamp Thymeleaf templates with modern layout and internal CSS
- Add local styles.css for consistent branding across pages

## Testing
- `mvn -q -pl frontend test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c07a55ca7c8330ad35c2915519eae1